### PR TITLE
Augment qr code generation with item and manufacturing order images

### DIFF
--- a/app/Console/Commands/TestQrTagGeneration.php
+++ b/app/Console/Commands/TestQrTagGeneration.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Production\Item;
+use App\Models\Production\ManufacturingOrder;
+use App\Services\Production\QrTagPdfService;
+use Illuminate\Console\Command;
+
+class TestQrTagGeneration extends Command
+{
+    protected $signature = 'test:qr-tags {type=item} {id=1}';
+    protected $description = 'Test QR tag generation with images';
+
+    public function handle(QrTagPdfService $qrTagService)
+    {
+        $type = $this->argument('type');
+        $id = $this->argument('id');
+
+        try {
+            if ($type === 'item') {
+                $item = Item::find($id);
+                if (!$item) {
+                    $this->error("Item with ID {$id} not found.");
+                    return 1;
+                }
+                
+                $this->info("Generating QR tag for Item: {$item->name} ({$item->item_number})");
+                $this->info("Primary Image URL: " . ($item->primary_image_url ?? 'No image'));
+                
+                $pdfUrl = $qrTagService->generateItemTag($item);
+                $this->info("PDF generated: {$pdfUrl}");
+                
+            } elseif ($type === 'order') {
+                $order = ManufacturingOrder::find($id);
+                if (!$order) {
+                    $this->error("Manufacturing Order with ID {$id} not found.");
+                    return 1;
+                }
+                
+                $this->info("Generating QR tag for MO: {$order->order_number}");
+                $this->info("Item: {$order->item->name} ({$order->item->item_number})");
+                $this->info("Has Route: " . ($order->has_route ? 'Yes' : 'No'));
+                
+                if (!$order->has_route) {
+                    $parentWithRoute = app(\App\Services\Production\QrCodeService::class)->findClosestParentWithRoute($order);
+                    if ($parentWithRoute) {
+                        $this->info("Parent with route found: MO {$parentWithRoute->order_number} - Item: {$parentWithRoute->item->name}");
+                    } else {
+                        $this->info("No parent with route found.");
+                    }
+                }
+                
+                $pdfUrl = $qrTagService->generateOrderTag($order);
+                $this->info("PDF generated: {$pdfUrl}");
+                
+            } else {
+                $this->error("Invalid type. Use 'item' or 'order'.");
+                return 1;
+            }
+            
+            return 0;
+            
+        } catch (\Exception $e) {
+            $this->error("Error: " . $e->getMessage());
+            $this->error($e->getTraceAsString());
+            return 1;
+        }
+    }
+}

--- a/app/Services/Production/QrCodeService.php
+++ b/app/Services/Production/QrCodeService.php
@@ -44,8 +44,8 @@ class QrCodeService
     {
         $current = $order;
         
-        while ($current->parent_order_id) {
-            $current = $current->parentOrder;
+        while ($current->parent_id) {
+            $current = $current->parent;
             if ($current->has_route) {
                 return $current;
             }

--- a/resources/views/pdf/qr-tags/batch.blade.php
+++ b/resources/views/pdf/qr-tags/batch.blade.php
@@ -54,11 +54,51 @@
             height: 25mm;
         }
         
-        .item-details {
+        .images-section {
             flex: 1;
             display: flex;
             flex-direction: column;
             justify-content: center;
+            gap: 3mm;
+            margin: 3mm 0;
+        }
+        
+        .item-image {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        
+        .item-image img {
+            max-width: 45mm;
+            max-height: 30mm;
+            object-fit: contain;
+        }
+        
+        .parent-image {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border-top: 1px dashed #ccc;
+            padding-top: 3mm;
+        }
+        
+        .parent-image img {
+            max-width: 35mm;
+            max-height: 25mm;
+            object-fit: contain;
+        }
+        
+        .parent-label {
+            font-size: 8pt;
+            color: #666;
+            margin-bottom: 2mm;
+            text-align: center;
+        }
+        
+        .item-details {
+            display: flex;
+            flex-direction: column;
             padding: 0 3mm;
         }
         
@@ -108,6 +148,28 @@
             
             <div class="qr-code">
                 <img src="data:image/png;base64,{{ $tag['qrCode'] }}" alt="QR Code">
+            </div>
+            
+            <div class="images-section">
+                @if($tag['type'] === 'item')
+                    @if(isset($tag['item_image_url']) && $tag['item_image_url'])
+                        <div class="item-image">
+                            <img src="{{ $tag['item_image_url'] }}" alt="{{ $tag['item']->name }}">
+                        </div>
+                    @endif
+                @else
+                    @if(isset($tag['item_image_url']) && $tag['item_image_url'])
+                        <div class="item-image">
+                            <img src="{{ $tag['item_image_url'] }}" alt="{{ $tag['item']->name }}">
+                        </div>
+                    @endif
+                    @if(isset($tag['parent_item_image_url']) && $tag['parent_item_image_url'] && $tag['parentItem'])
+                        <div class="parent-label">Roteamento via: {{ $tag['parentItem']->name }}</div>
+                        <div class="parent-image">
+                            <img src="{{ $tag['parent_item_image_url'] }}" alt="{{ $tag['parentItem']->name }}">
+                        </div>
+                    @endif
+                @endif
             </div>
             
             <div class="item-details">

--- a/resources/views/pdf/qr-tags/item-tag.blade.php
+++ b/resources/views/pdf/qr-tags/item-tag.blade.php
@@ -97,9 +97,9 @@
             <img src="data:image/png;base64,{{ $qrCode }}" alt="QR Code">
         </div>
         
-        @if($item->image_url ?? false)
+        @if($item->primary_image_url)
             <div class="item-image">
-                <img src="{{ $item->image_url }}" alt="{{ $item->name }}">
+                <img src="{{ $item->primary_image_url }}" alt="{{ $item->name }}">
             </div>
         @endif
         

--- a/resources/views/pdf/qr-tags/order-tag.blade.php
+++ b/resources/views/pdf/qr-tags/order-tag.blade.php
@@ -120,17 +120,17 @@
         </div>
         
         <div class="images-section">
-            @if($item->image_url ?? false)
+            @if($item && $item->primary_image_url)
                 <div class="item-image">
-                    <img src="{{ $item->image_url }}" alt="{{ $item->name }}">
+                    <img src="{{ $item->primary_image_url }}" alt="{{ $item->name }}">
                 </div>
             @endif
             
-            @if($parentItem && ($parentItem->image_url ?? false))
+            @if($parentItem && $parentItem->primary_image_url)
                 <div class="parent-section">
                     <div class="parent-label">Roteamento via:</div>
                     <div class="parent-image">
-                        <img src="{{ $parentItem->image_url }}" alt="{{ $parentItem->name }}">
+                        <img src="{{ $parentItem->primary_image_url }}" alt="{{ $parentItem->name }}">
                     </div>
                 </div>
             @endif


### PR DESCRIPTION
Add item and parent item images to QR Code tags for items and manufacturing orders to improve visual identification.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ef2209c-4715-434f-952a-716fd2c58367">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2ef2209c-4715-434f-952a-716fd2c58367">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>